### PR TITLE
feat: automate releases and generate slsa provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Publish
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'temurin'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  precheck:
+    if: github.repository == 'eclipse-cbi/macos-notarization-service'
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.vars.outputs.VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+          cache: maven
+
+      - name: Version
+        id: vars
+        shell: bash
+        run: |
+          PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "PROJECT_VERSION=$(echo $PROJECT_VERSION)" >> $GITHUB_OUTPUT
+
+          echo "GitHub ref name: $GITHUB_REF_NAME"
+          echo "Project version: $PROJECT_VERSION"
+
+          # Check that the project version matches the GitHub ref name
+          test "v$PROJECT_VERSION" == "$GITHUB_REF_NAME"
+
+  build:
+    needs: ['precheck']
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.hash.outputs.hash }}
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+          cache: maven
+      - run: ./mvnw -ntp -Pdist clean package
+      # Generate hashes used for provenance.
+      - name: generate hash
+        id: hash
+        run: cd target/distributions && echo "hash=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          path: target/distributions
+
+  update_release_draft:
+    needs: ['precheck']
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Update the release notes for the released version
+      - uses: release-drafter/release-drafter@v5
+        with:
+          tag: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  provenance:
+    needs: ['build']
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    # Can't pin with hash due to how this workflow works.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    with:
+      base64-subjects: ${{ needs.build.outputs.hash }}
+
+  upload-artifacts:
+    # Upload the distribution and provenance to a GitHub release. They remain
+    # available as build artifacts for a while as well.
+    needs: ['provenance', 'update_release_draft']
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: upload artifacts to release
+        run: >
+          gh release upload --repo ${{ github.repository }}
+          ${{ github.ref_name }}
+          *.intoto.jsonl/* artifact/*
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,14 @@
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.parameters>true</maven.compiler.parameters>
 
+		<distribution.directory>${project.build.directory}/distributions</distribution.directory>
+
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
 		<quarkus.platform.version>3.3.2</quarkus.platform.version>
 		<quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
+		<quarkus.native.additional-build-args>--initialize-at-run-time=com.google.common.cache</quarkus.native.additional-build-args>
+		<quarkus.native.compression.level>5</quarkus.native.compression.level>
 
 		<surefire-plugin.version>3.1.2</surefire-plugin.version>
 		<compiler-plugin.version>3.11.0</compiler-plugin.version>
@@ -266,6 +270,37 @@
 										<native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
 									</systemProperties>
 								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>dist</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<version>3.3.0</version>
+						<configuration>
+							<attach>false</attach>
+							<appendAssemblyId>false</appendAssemblyId>
+							<finalName>${project.artifactId}-${project.version}</finalName>
+							<outputDirectory>${distribution.directory}</outputDirectory>
+							<workDirectory>${project.build.directory}/assembly/work</workDirectory>
+							<descriptors>
+								<descriptor>src/main/assembly/assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+						<executions>
+							<execution>
+								<id>make-distribution</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
 							</execution>
 						</executions>
 					</plugin>

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -1,0 +1,25 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>dist</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/quarkus-app</directory>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>LICENSE</source>
+            <outputDirectory>.</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+    </files>
+</assembly>


### PR DESCRIPTION
This fixes #239 .

It uses the existing release-drafter config and the generic slsa generator workflow.

This PR adds the following changes:

- adds a new workflow release.yml that triggers when tags with name [v*] are being created
- it will build the app as distribution (zip file), generate slsa provenance for it and attach it to a release prepared by release drafter
- after the release preparation have been completed, you can manually publish the release (it will be a draft after the workflow has been completed)

This PR is an attempt to automate releases using existing configurations. In the long term, switch to jreleaser seems like the way to go, however this will affect the release notes. Also the builder workflow for jreleaser and slsa is not really mature atm, using the generic generator is a safe solution for now imho.

cc @mbarbero 