### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
           cache: maven
-      - run: ./mvnw -ntp clean verify
+      - run: ./mvnw -ntp clean verify -Psbom

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    
+    # don't run this workflow in forks
+    if: github.repository == 'eclipse-cbi/macos-notarization-service'
+
     permissions:
       # required for all workflows
       security-events: write
@@ -37,9 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'java' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   dependency:
     runs-on: ubuntu-latest
+    # don't run this workflow in forks
+    if: github.repository == 'eclipse-cbi/macos-notarization-service'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,9 +10,15 @@ on:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    # don't run this workflow in forks
+    if: github.repository == 'eclipse-cbi/macos-notarization-service'
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 env:
+  BOT_USER_NAME: eclipse-cbi-bot
+  BOT_EMAIL: cbi-bot@eclipse.org
   JAVA_VERSION: '17'
   JAVA_DISTRO: 'temurin'
 
@@ -12,69 +12,73 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
-  precheck:
-    if: github.repository == 'eclipse-cbi/macos-notarization-service'
-    runs-on: ubuntu-latest
-    outputs:
-      VERSION: ${{ steps.vars.outputs.VERSION }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRO }}
-          cache: maven
-
-      - name: Version
-        id: vars
-        shell: bash
-        run: |
-          PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "PROJECT_VERSION=$(echo $PROJECT_VERSION)" >> $GITHUB_OUTPUT
-
-          echo "GitHub ref name: $GITHUB_REF_NAME"
-          echo "Project version: $PROJECT_VERSION"
-
-          # Check that the project version matches the GitHub ref name
-          test "v$PROJECT_VERSION" == "$GITHUB_REF_NAME"
-
   build:
-    needs: ['precheck']
     runs-on: ubuntu-latest
+    # don't run this workflow in forks
+    if: github.repository == 'eclipse-cbi/macos-notarization-service'
+    permissions:
+      contents: write
     outputs:
+      tag: ${{ steps.retrieve-tag.outputs.tag }}
       hash: ${{ steps.hash.outputs.hash }}
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - name: Setup Git User
+        run: |
+          git config --global user.name '${{ env.BOT_USER_NAME }}'
+          git config --global user.email '${{ env.BOT_EMAIL }}'
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.ref }}
+
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
           cache: maven
-      - run: ./mvnw -ntp -Pdist clean package
-      # Generate hashes used for provenance.
+
+      - name: Build Release
+        run: |
+          ./mvnw -ntp -B -Prelease release:clean release:prepare -Dmaven.test.skip=true
+          ./mvnw -ntp -B -Pdist -Prelease -Psbom release:perform -Darguments="-Dmaven.deploy.skip=true" -Dgoals=package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: retrieve-tag
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+      - if: cancelled() || failure()
+        run: ./mvnw -B -Prelease release:rollback
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        # Generate hashes used for provenance.
       - name: generate hash
         id: hash
-        run: cd target/distributions && echo "hash=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        run: cd target/checkout/target/distributions && echo "hash=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
-          path: target/distributions
+          path: target/checkout/target/distributions
+
 
   update_release_draft:
-    needs: ['precheck']
+    needs: ['build']
     permissions:
       contents: write
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
       # Update the release notes for the released version
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.25.0
         with:
-          tag: ${{ github.ref_name }}
+          tag: ${{ needs.build.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,16 +96,16 @@ jobs:
   upload-artifacts:
     # Upload the distribution and provenance to a GitHub release. They remain
     # available as build artifacts for a while as well.
-    needs: ['provenance', 'update_release_draft']
+    needs: ['build', 'provenance', 'update_release_draft']
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       - name: upload artifacts to release
         run: >
           gh release upload --repo ${{ github.repository }}
-          ${{ github.ref_name }}
+          ${{ needs.build.outputs.tag }}
           *.intoto.jsonl/* artifact/*
         env:
           GH_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.cbi</groupId>
 	<artifactId>macos-notarization-service</artifactId>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<properties>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.cbi</groupId>
 	<artifactId>macos-notarization-service</artifactId>
@@ -7,7 +7,7 @@
 	<properties>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.outputTimestamp>1695646139</project.build.outputTimestamp>
+		<project.build.outputTimestamp>1698421459</project.build.outputTimestamp>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.parameters>true</maven.compiler.parameters>
@@ -39,10 +39,11 @@
 	</repositories>
 
 	<scm>
-		<connection>scm:git:https://github.com/eclipse-cbi/macos-notarization-service</connection>
-		<developerConnection>scm:git:ssh://github.com/eclipse-cbi/macos-notarization-service</developerConnection>
-		<url>https://github.com/eclipse-cbi/macos-notarization-service</url>
-	</scm>
+		<connection>scm:git:${project.scm.url}</connection>
+		<developerConnection>scm:git:${project.scm.url}</developerConnection>
+		<url>https://github.com/eclipse-cbi/macos-notarization-service.git</url>
+		<tag>HEAD</tag>
+    </scm>
 
 	<dependencyManagement>
 		<dependencies>
@@ -220,31 +221,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.cyclonedx</groupId>
-				<artifactId>cyclonedx-maven-plugin</artifactId>
-				<version>2.7.9</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>makeAggregateBom</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.owasp</groupId>
-				<artifactId>dependency-check-maven</artifactId>
-				<version>8.4.0</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 	<profiles>
@@ -281,6 +257,22 @@
 			</build>
 		</profile>
 		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-release-plugin</artifactId>
+						<version>3.0.1</version>
+						<configuration>
+							<projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
+							<tagNameFormat>v@{project.version}</tagNameFormat>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>dist</id>
 			<build>
 				<plugins>
@@ -304,6 +296,38 @@
 								<phase>package</phase>
 								<goals>
 									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>sbom</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.cyclonedx</groupId>
+						<artifactId>cyclonedx-maven-plugin</artifactId>
+						<version>2.7.9</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>makeAggregateBom</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.owasp</groupId>
+						<artifactId>dependency-check-maven</artifactId>
+						<version>8.4.0</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>check</goal>
 								</goals>
 							</execution>
 						</executions>


### PR DESCRIPTION
This fixes #255 .

This PR includes various improvements:

- make release fully automated using the maven release plugin
- separate sbom related plugins to a separate profile
- small improvements to the existing workflows to ensure they are only run in this repo not in forks

In order to make a release, just trigger the release workflow manually. The workflow will automatically setup the version for the release, tag, upload the release and bump the version to the next development version afterwards.

The release is prepared as draft, once everything is fine, you can publish it.

I tested the workflow extensively in my own fork, but cleaned up all generated tags / releases after it was finally successful. In order for the workflow to succeed, various things have to be setup correctly in the fork, so running the workflow as is in my fork will eventually fail. So after the workflow was working I modified the branch for the PR to the eclipse-cbi version and squashed all commits.

Edit: I have now run the release workflow in my fork with necessary changes (https://github.com/netomi/macos-notarization-service/commit/ce51ff04021ac4de3a1974159a9df36896076ba4): https://github.com/netomi/macos-notarization-service/actions/runs/6670304472 , the workflow just failed in the last step, uploading the artifacts to the draft release as the artifacts were already there (from a previous run).

Resulting in this release: https://github.com/netomi/macos-notarization-service/releases/tag/v1.2.1
Pom is updated afterwards: https://github.com/netomi/macos-notarization-service/commit/d1502737d76208060479ec2a78d0366d9552d8f8

Using the maven release plugin is a bit of a pain. In the long run we should use jreleaser and also get rid of the release drafter imho.