### PR TITLE
Plugin changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,9 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
           cache: maven
-      - run: ./mvnw -ntp clean verify -Psbom
+      - name: Build and verify
+        run: ./mvnw -ntp clean verify
+      - name: Upload artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          path: target/macos-notarization-service-*

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,23 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.cyclonedx</groupId>
+				<artifactId>cyclonedx-maven-plugin</artifactId>
+				<version>2.7.10</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>makeBom</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<outputFormat>json</outputFormat>
+					<outputName>${project.build.finalName}-cyclonedx</outputName>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<version>3.4.1</version>
@@ -304,22 +321,9 @@
 			</build>
 		</profile>
 		<profile>
-			<id>sbom</id>
+			<id>dependency-check</id>
 			<build>
 				<plugins>
-					<plugin>
-						<groupId>org.cyclonedx</groupId>
-						<artifactId>cyclonedx-maven-plugin</artifactId>
-						<version>2.7.10</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>makeAggregateBom</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
 					<plugin>
 						<groupId>org.owasp</groupId>
 						<artifactId>dependency-check-maven</artifactId>


### PR DESCRIPTION
This PR does the following:

- reorganize sbom generation to enable it by default
- move dependency check plugin into a separate profile
- update ci workflow to upload generated artifacts