### PR TITLE
feat: improve error handling during submission

### DIFF
--- a/src/main/java/org/eclipse/cbi/ws/macos/notarization/process/NativeProcess.java
+++ b/src/main/java/org/eclipse/cbi/ws/macos/notarization/process/NativeProcess.java
@@ -122,6 +122,10 @@ public class NativeProcess {
 			return Files.newInputStream(stdout, StandardOpenOption.READ);
 		}
 
+		public InputStream stderrAsStream() throws IOException {
+			return Files.newInputStream(stderr, StandardOpenOption.READ);
+		}
+
 		Result log() {
 			LOGGER.trace(this.toString());
 			if (exitValue == 0) {

--- a/src/test/java/org/eclipse/cbi/ws/macos/notarization/xcrun/notarytool/NotarytoolNotarizerTest.java
+++ b/src/test/java/org/eclipse/cbi/ws/macos/notarization/xcrun/notarytool/NotarytoolNotarizerTest.java
@@ -17,8 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NotarytoolNotarizerTest {
 
@@ -47,6 +46,26 @@ public class NotarytoolNotarizerTest {
         assertEquals(NotarizerResult.Status.UPLOAD_SUCCESSFUL, result.status());
         assertEquals("ac9a4320-49c8-453c-82a3-996d83bd20f5", result.appleRequestUUID());
         assertEquals("Successfully uploaded file", result.message());
+    }
+
+    @Test
+    public void analyzeFailureSubmissionDueToRequiredAgreement() throws ExecutionException {
+        Path stdout = Path.of(this.getClass().getResource("submission-empty.log").getPath());
+        Path stderr = Path.of(this.getClass().getResource("submission-failure.log").getPath());
+
+        NativeProcess.Result r =
+                NativeProcess.Result.builder()
+                        .exitValue(0)
+                        .arg0("")
+                        .stdout(stdout)
+                        .stderr(stderr)
+                        .build();
+
+        NotarizerResult result = tool.analyzeSubmissionResult(r, Path.of("SuperDuper.dmg"));
+
+        assertEquals(NotarizerResult.Status.UPLOAD_FAILED, result.status());
+        assertTrue(result.message().startsWith("Failed to notarize the requested file. Reason: Error: " +
+                "HTTP status code: 403. A required agreement is missing or has expired."));
     }
 
     @Test

--- a/src/test/resources/org/eclipse/cbi/ws/macos/notarization/xcrun/notarytool/submission-failure.log
+++ b/src/test/resources/org/eclipse/cbi/ws/macos/notarization/xcrun/notarytool/submission-failure.log
@@ -1,0 +1,1 @@
+Error: HTTP status code: 403. A required agreement is missing or has expired. This request requires an in-effect agreement that has not been signed or has expired. Ensure your team has signed the necessary legal agreements and that they are not expired.


### PR DESCRIPTION
This PR improves error handling when a submission fails.

In some cases, calling notarytool fails with an error as some license agreements need to be manually accepted. The tool will print this to stderr. Parsing the output from the tool in such cases resulting in an exception as the captured stdout was empty and a generic error message was returned.

Now, if an exception is thrown during parsing, the error output is captured and used for the returned value so that you immediately know whats going on.